### PR TITLE
set up gitignore for private data directory

### DIFF
--- a/Data/private/.gitignore
+++ b/Data/private/.gitignore
@@ -1,0 +1,4 @@
+# non-public data should be stored in this directory
+# this file ensures its contents are not synced to github
+*
+!.gitignore


### PR DESCRIPTION
SDI data shouldn't live on public servers - setting up a directory where collaborators can download and refer to data without it ending up on github